### PR TITLE
Fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,0 @@
-
-module.exports = require("./lib/memory");
-
-/* EOF */

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -1,5 +1,5 @@
 
-module.exports =  memory = function(kDec, returnMBString) {
+module.exports = function memory(kDec, returnMBString) {
 	kDec = kDec || 2;
 	returnMBString = returnMBString || false;
 	var memoryObj = process.memoryUsage();

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "keywords": ["memory", "usage", "twitter", "rss", "megabytes"],
     "main": "./index",
     "engines": {
-      "node": "~v0.4.11"
+      "node": ">= 0.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "git://github.com/edwardhotchkiss/memory.git"
     },
     "keywords": ["memory", "usage", "twitter", "rss", "megabytes"],
-    "main": "./index",
+    "main": "./lib/memory",
     "engines": {
       "node": ">= 0.4"
     }


### PR DESCRIPTION
Changes:
- `package.json` matches `node >= 0.4` now, not `node v0.4.11`, as before
- `index.js` was removed, `main` in `package.json` points to `./lib/memory` now
- we were leaking `memory` function into global context (it's a bit weird, I didn't see it in `node v0.4.12`, but it appeared on `node v0.6.0`)
